### PR TITLE
Include newly-split chapter in PDF.

### DIFF
--- a/main.tex
+++ b/main.tex
@@ -17,6 +17,7 @@
 \include{compiled_tex/33_exploratory_testing.tex}
 \include{compiled_tex/35_automated_testing.tex}
 \include{compiled_tex/40_unit_testing.tex}
+\include{compiled_tex/41_advanced_unit_testing.tex}
 \include{compiled_tex/45_test_driven_development.tex}
 \include{compiled_tex/50_writing_testable_code.tex}
 \include{compiled_tex/60_combinatorial_testing.tex}

--- a/text/25_test_plans.md
+++ b/text/25_test_plans.md
@@ -336,7 +336,7 @@ FUN-TEA-ERROR: 8
 
 It's easy to see that for each requirement, there is at least one test covering it.  If there were another requirement, say:
 
-__FUN-COFFEE-FROZEN.__ If the coffee is in a solid and not a liquid state, then the app shall display `THIS COFFEE CAN ONLY BE EATEN, NOT DRUNK` message.
+* __FUN-COFFEE-FROZEN.__ If the coffee is in a solid and not a liquid state, then the app shall display `THIS COFFEE CAN ONLY BE EATEN, NOT DRUNK` message.
 
 and we tried to create a traceability matrix, it would be very easy to see that there were no tests checking for this requirement.
 

--- a/text/99_acknowledgements.md
+++ b/text/99_acknowledgements.md
@@ -2,6 +2,6 @@
 
 Thanks to everybody who has helped make this book a reality or made it into a better reality, especially:
 
-_Ross Acheson, Robbie McKinstry
+_Ross Acheson, Robbie McKinstry_
 
 Special thanks go to __Tim Parenti__, who found more typos and errors than I ever would have thought possible, and even better, did an excellent job fixing many of them.


### PR DESCRIPTION
A few minor formatting fixes introduced by recent changes, most notably including file 41 (newly split from file 40 in 497cbedd400395c182be37f6c0992732df483f9f per #11) in the PDF.