### PR TITLE
Changed printQuock() access and LaboonStuff class name

### DIFF
--- a/text/96_private_methods_java.md
+++ b/text/96_private_methods_java.md
@@ -181,7 +181,7 @@ public class LaboonStuff {
 @Test
 public void testPrivateLaboonify() {
     try {
-        Method method = MathStuff.class.getDeclaredMethod("laboonify");
+        Method method = LaboonStuff.class.getDeclaredMethod("laboonify");
         method.setAccessible(true);
         LaboonStuff ls = new LaboonStuff();
         Object returnValue = method.invoke(ls, 4);


### PR DESCRIPTION
The method printQuock() was incorrectly declared as public in the example code even though it was stated that printQuock() would be added as a private method.

Also changed a call from a MathStuff class to the LaboonStuff class in the testPrivateLaboonify() method.