### PR TITLE
Update Makefile/README for pandoc ~> 2.0.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,8 +13,8 @@ MD_FILES=	$(wildcard text/*.md)
 pdf:	main.tex tex_files
 # Uses date of most recent commit in repo
 	$(PANDOC) main.tex -o software-testing-laboon-ebook.pdf \
-		--latex-engine $(XELATEX) \
-		--chapters -N --toc --toc-depth=2 \
+		--pdf-engine $(XELATEX) \
+		--top-level-division=chapter -N --toc --toc-depth=2 \
 		-M documentclass="book" \
 		-M classoption="twoside" \
 		-M classoption="letterpaper" \

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ This textbook is comprised of a series of Markdown files, compiled into PDF
 format via PDF\LaTeX.  Required dependencies, available through most package
 managers, include:
 
-* [`pandoc`](http://johnmacfarlane.net/pandoc/)
+* [`pandoc`](http://johnmacfarlane.net/pandoc/), at least version 2.0
 * [`pdflatex`](http://www.tug.org/applications/pdftex/)
 * `xelatex` --- available in [TeX Live](http://tug.org/texlive/)
 


### PR DESCRIPTION
* --chapters was deprecated in 1.18 in favor of --top-level-division
* --latex-engine became --pdf-engine in 2.0

Partially addresses #139.