### PR TITLE
changed "pdf-engine" to "latex-engine"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ MD_FILES=	$(wildcard text/*.md)
 pdf:	main.tex tex_files
 # Uses date of most recent commit in repo
 	$(PANDOC) main.tex -o software-testing-laboon-ebook.pdf \
-		--pdf-engine $(XELATEX) \
+		--latex-engine $(XELATEX) \
 		--top-level-division=chapter -N --toc --toc-depth=2 \
 		-M documentclass="book" \
 		-M classoption="twoside" \


### PR DESCRIPTION
Otherwise "make" does not work, pandoc 1.19.2.1. Compiled with pandoc-types 1.17.0.4, texmath 0.9, skylighting 0.1.1.4, on MacOS 10.12.6