### PR TITLE
Adapt flag for pandoc version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,11 +9,17 @@ XELATEX= xelatex
 
 MD_FILES=	$(wildcard text/*.md)
 
+PANDOC_VERSION=$(shell pandoc --version | grep -o -e 'pandoc [0-9]' | cut -d ' ' -f 2 -)
+ENGINE_FLAG=--pdf-engine
+ifeq ($(PANDOC_VERSION),1)
+	ENGINE_FLAG=--latex-engine
+endif
+
 
 pdf:	main.tex tex_files
 # Uses date of most recent commit in repo
 	$(PANDOC) main.tex -o software-testing-laboon-ebook.pdf \
-		--pdf-engine $(XELATEX) \
+		$(ENGINE_FLAG) $(XELATEX) \
 		--top-level-division=chapter -N --toc --toc-depth=2 \
 		-M documentclass="book" \
 		-M classoption="twoside" \


### PR DESCRIPTION
Hey, the Makefile uses the `--pdf-engine` pandoc option, but it used to be called `--latex-engine` in pandoc 1.x and was renamed for 2.x. Ubuntu (and presumably Debian) still have 1.x in their repositories, so I thought it would be nice if the Makefile adapted automatically. I tested this on both 1.x and 2.x (installed manually) on Ubuntu 18.04. The PDF compiles successfully under both. I think my 2.x install failed to find some LaTeX packages (specifically, the `\huge` usages on the title page show up inline), so you may want to verify.